### PR TITLE
Update the Powered By BrigadeHub to go to the github.io page

### DIFF
--- a/views/partials/footer.pug
+++ b/views/partials/footer.pug
@@ -37,4 +37,4 @@ footer
         li.text-center
           a(href='https://goo.gl/forms/2SMf3qX8ihfqvEC13' target='_blank') brigadehub feedback
         li.float.right
-          a(href='https://github.com/sfbrigade/brigadehub') powered by brigadehub
+          a(href='https://brigadehub.github.io/') powered by BrigadeHub


### PR DESCRIPTION
Also changed the text to BrigadeHub, because consistency.