### PR TITLE
Switch checkin email input type to email

### DIFF
--- a/views/checkin/checkinForm.pug
+++ b/views/checkin/checkinForm.pug
@@ -22,7 +22,7 @@ form(action='/checkin', method='post')
     .form-group.row
       label.col-sm-3.control-label(for='email') Email
       .col-sm-7
-        input.form-control(type='text', name='email', id='email', placeholder='e.g. civichacking@example.com')
+        input.form-control(type='email', name='email', id='email', placeholder='e.g. civichacking@example.com')
     .form-group.row
       label.col-sm-3.control-label(for='githubUsername') Github Username
       .col-sm-3


### PR DESCRIPTION
On the CheckInForm, use html5 input type 'email' for email input field.  This allows browsers (particularly mobile) to render appropriate keypads.  See http://caniuse.com/#feat=input-email-tel-url for browser compatibility.

For example, on Android now the keypad has an `@` symbol:

![screenshot_20170413-133759](https://cloud.githubusercontent.com/assets/384389/25024094/731e8eda-2051-11e7-9c77-b2cc2315df90.png)

Won't lie, I thought it'd be more than just an `@` symbol.  But life's about the small things right?
